### PR TITLE
feat(http): enable CORS for MCP endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vidcap-mcp-server",
-	"version": "1.0.0",
+	"version": "1.3.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vidcap-mcp-server",
-			"version": "1.0.0",
+			"version": "1.3.0",
 			"license": "ISC",
 			"dependencies": {
 				"@aws-sdk/client-s3": "^3.803.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { config } from './utils/config.util.js';
 import { VERSION, PACKAGE_NAME } from './utils/constants.util.js';
 import { runCli } from './cli/index.js';
 import express from 'express';
+import cors from 'cors';
 import { randomUUID } from 'crypto';
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 
@@ -108,6 +109,26 @@ export async function startServer(mode: 'stdio' | 'http' = 'stdio') {
 
 		// Create Express app
 		expressApp = express();
+
+		// Enable CORS for browser-based MCP clients (e.g. Claude.ai Connectors).
+		// Expose mcp-session-id so clients can read it from response headers.
+		expressApp.use(
+			cors({
+				origin: true,
+				credentials: true,
+				methods: ['GET', 'POST', 'DELETE', 'OPTIONS'],
+				allowedHeaders: [
+					'Content-Type',
+					'Authorization',
+					'mcp-session-id',
+					'mcp-protocol-version',
+					'Last-Event-ID',
+					'Accept',
+				],
+				exposedHeaders: ['mcp-session-id', 'mcp-protocol-version'],
+			}),
+		);
+
 		expressApp.use(express.json());
 
 		// Add API key middleware to extract query param


### PR DESCRIPTION
## What

Register the `cors` middleware on the Express app in `src/index.ts` so browser-based MCP clients (e.g. Claude.ai Connectors) can reach `/mcp`.

- Allows any origin (`origin: true`) with credentials.
- Permits the headers MCP clients actually send: `Content-Type`, `Authorization`, `mcp-session-id`, `mcp-protocol-version`, `Last-Event-ID`, `Accept`.
- Exposes `mcp-session-id` and `mcp-protocol-version` so the client can read them from response headers.
- Methods: `GET, POST, DELETE, OPTIONS`.

## Why

Production was returning `200` on `OPTIONS /mcp` with no `Access-Control-*` headers at all. Any browser-side MCP client hits the same-origin policy before reaching the server, and the response \`mcp-session-id\` header isn't readable without \`Access-Control-Expose-Headers\`. This is the most likely cause of the \"Error occurred during tool execution\" wrapper Claude was showing for \`youtube_getInfo\` calls.

## Verification

After \`dx up --prod\`:

\`\`\`
$ curl -i -X OPTIONS https://mcpservers-vidcap.prod.diginext.site/mcp \\
    -H 'Origin: https://claude.ai' \\
    -H 'Access-Control-Request-Method: POST' \\
    -H 'Access-Control-Request-Headers: content-type,mcp-session-id'

HTTP/2 204
access-control-allow-origin: https://claude.ai
access-control-allow-credentials: true
access-control-allow-methods: GET,POST,DELETE,OPTIONS
access-control-allow-headers: Content-Type,Authorization,mcp-session-id,mcp-protocol-version,Last-Event-ID,Accept
access-control-expose-headers: mcp-session-id,mcp-protocol-version
\`\`\`

\`npm run build\` passes. Existing protocol behavior unchanged — \`initialize\` / \`notifications/initialized\` / \`tools/list\` / \`tools/call\` flows all continue to work through curl.

## Notes for reviewer

- \`cors\` and \`@types/cors\` were already in \`package.json\` dependencies — just not wired up.
- If \`origin: true\` is too permissive, we can narrow to \`['https://claude.ai', 'https://*.anthropic.com']\` in a follow-up.
- If Claude still reports the same error after this lands, the next candidate is upgrading \`@modelcontextprotocol/sdk\` from \`^1.11.0\` to the current \`1.29.0\` — the Streamable HTTP transport has had multiple fixes since 1.11.